### PR TITLE
[FIX] Explicit type-casting the `vocab` into a dictionary object

### DIFF
--- a/src/autotiktokenizer/autotiktokenizer.py
+++ b/src/autotiktokenizer/autotiktokenizer.py
@@ -183,7 +183,7 @@ class AutoTikTokenizer:
             vocab (dict): The vocabulary of the tokenizer.
         """
         try:
-            vocab = tokenizer["model"]["vocab"]
+            vocab = dict(tokenizer["model"]["vocab"])
         except KeyError:
             raise Warning(
                 "No vocab found inside tokenizer.json"


### PR DESCRIPTION
An explicit type-casting of the `vocab` variable will handle this issue when the `vocab` is presented as a list of lists in any `tokenizer.json`